### PR TITLE
tests: Fix visibility for methods overriding TestCase::setUp() 

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -69,6 +69,7 @@ $config
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
         'psr_autoloading' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/tests/Config/MysqlYamlTest.php
+++ b/tests/Config/MysqlYamlTest.php
@@ -14,7 +14,7 @@ class MysqlYamlTest extends TestCase
 {
     protected array $functions;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $yaml = new Parser();
 

--- a/tests/Query/DbTestCase.php
+++ b/tests/Query/DbTestCase.php
@@ -15,7 +15,7 @@ class DbTestCase extends TestCase
 
     protected Configuration $configuration;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configuration = new Configuration();
         $this->configuration->setMetadataCache(new ArrayAdapter());

--- a/tests/Query/Mysql/TrigTest.php
+++ b/tests/Query/Mysql/TrigTest.php
@@ -10,7 +10,7 @@ class TrigTest extends MysqlTestCase
 {
     private $entity;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Query/MysqlTestCase.php
+++ b/tests/Query/MysqlTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class MysqlTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::MYSQL);

--- a/tests/Query/OracleTestCase.php
+++ b/tests/Query/OracleTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class OracleTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::ORACLE);

--- a/tests/Query/PostgresqlTestCase.php
+++ b/tests/Query/PostgresqlTestCase.php
@@ -4,7 +4,7 @@ namespace DoctrineExtensions\Tests\Query;
 
 class PostgresqlTestCase extends DbTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::POSTGRES);

--- a/tests/Query/SqliteTestCase.php
+++ b/tests/Query/SqliteTestCase.php
@@ -11,7 +11,7 @@ class SqliteTestCase extends DbTestCase
      */
     protected $columnAlias;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         ConfigLoader::load($this->configuration, ConfigLoader::SQLITE);

--- a/tests/Types/CarbonDateTest.php
+++ b/tests/Types/CarbonDateTest.php
@@ -44,7 +44,7 @@ class CarbonDateTest extends TestCase
         Type::addType('CarbonImmutableTime', CarbonImmutableTimeType::class);
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $config = new Configuration();
         $config->setMetadataCache(new ArrayAdapter());

--- a/tests/Types/ZendDateTest.php
+++ b/tests/Types/ZendDateTest.php
@@ -31,7 +31,7 @@ class ZendDateTest extends TestCase
         );
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $config = new Configuration();
         $config->setMetadataCache(new ArrayAdapter());


### PR DESCRIPTION
and TestCase::tearDown()

From https://github.com/beberlei/DoctrineExtensions/pull/367