### PR TITLE
Replaced Token ArrayAccess in ConcatWs.php

### DIFF
--- a/src/Query/Mysql/ConcatWs.php
+++ b/src/Query/Mysql/ConcatWs.php
@@ -33,7 +33,7 @@ class ConcatWs extends FunctionNode
             $parser->match(Lexer::T_COMMA);
             $peek = $lexer->glimpse();
 
-            $this->values[] = $peek['value'] == '('
+            $this->values[] = $peek->value == '('
                     ? $parser->FunctionDeclaration()
                     : $parser->ArithmeticExpression();
         }


### PR DESCRIPTION
User Deprecated: Accessing Doctrine\Common\Lexer\Token properties via ArrayAccess is deprecated, use the value, type or position property instead (Token.php:108 called by ConcatWs.php:36