### PR TITLE
Upgrading doctrine/orm v2 to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,15 @@
     "description": "A set of extensions to Doctrine 2 that add support for additional query functions available in MySQL, Oracle, PostgreSQL and SQLite.",
     "keywords": ["doctrine", "orm", "database"],
     "license": "BSD-3-Clause",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"},
         {"name": "Steve Lacey", "email": "steve@steve.ly"}
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/orm": "^2.9"
+        "doctrine/orm": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.38",
@@ -31,7 +33,7 @@
     },
     "scripts": {
         "lint": "php-cs-fixer fix --ansi --diff --show-progress=none --verbose",
-        "test": "phpunit --colors=always",
+        "test": "phpunit --colors=auto",
         "phpstan": "phpstan analyse"
     }
 }

--- a/src/Query/Mysql/Acos.php
+++ b/src/Query/Mysql/Acos.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Acos extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Acos extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/AddTime.php
+++ b/src/Query/Mysql/AddTime.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Pascal Wacker <hello@pascalwacker.ch>
@@ -23,15 +23,15 @@ class AddTime extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->time = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/AesDecrypt.php
+++ b/src/Query/Mysql/AesDecrypt.php
@@ -3,25 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class AesDecrypt extends FunctionNode
 {
     public $field = '';
 
     public $key = '';
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->StringExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->key = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -30,5 +20,15 @@ class AesDecrypt extends FunctionNode
             $this->field->dispatch($sqlWalker),
             $this->key->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->StringExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->key = $parser->StringExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/AesEncrypt.php
+++ b/src/Query/Mysql/AesEncrypt.php
@@ -3,25 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class AesEncrypt extends FunctionNode
 {
     public $field = '';
 
     public $key = '';
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->StringExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->key = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -30,5 +20,15 @@ class AesEncrypt extends FunctionNode
             $this->field->dispatch($sqlWalker),
             $this->key->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->StringExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->key = $parser->StringExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/AnyValue.php
+++ b/src/Query/Mysql/AnyValue.php
@@ -3,21 +3,13 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class AnyValue extends FunctionNode
 {
     public $value;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->value = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -25,5 +17,13 @@ class AnyValue extends FunctionNode
             'ANY_VALUE(%s)',
             $this->value->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->value = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Ascii.php
+++ b/src/Query/Mysql/Ascii.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Ascii extends FunctionNode
 {
@@ -18,11 +18,11 @@ class Ascii extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->string = $parser->ArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Asin.php
+++ b/src/Query/Mysql/Asin.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Asin extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Asin extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Atan.php
+++ b/src/Query/Mysql/Atan.php
@@ -3,10 +3,10 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Atan extends FunctionNode
 {
@@ -32,19 +32,19 @@ class Atan extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
         try {
-            $parser->match(Lexer::T_COMMA);
+            $parser->match(TokenType::T_COMMA);
 
             $this->optionalSecondExpression = $parser->SimpleArithmeticExpression();
 
-            $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+            $parser->match(TokenType::T_CLOSE_PARENTHESIS);
         } catch (QueryException $e) {
-            $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+            $parser->match(TokenType::T_CLOSE_PARENTHESIS);
         }
     }
 }

--- a/src/Query/Mysql/Atan2.php
+++ b/src/Query/Mysql/Atan2.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Atan2 extends FunctionNode
 {
@@ -28,15 +28,15 @@ class Atan2 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->firstExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->secondExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/BinToUuid.php
+++ b/src/Query/Mysql/BinToUuid.php
@@ -3,30 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class BinToUuid extends FunctionNode
 {
     public $binaryUuid = null;
 
     public $swapFlag = null;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->binaryUuid = $parser->ArithmeticPrimary();
-
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
-            $this->swapFlag = $parser->Literal();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -37,5 +22,20 @@ class BinToUuid extends FunctionNode
         $sql .= ')';
 
         return $sql;
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->binaryUuid = $parser->ArithmeticPrimary();
+
+        if (TokenType::T_COMMA === $parser->getLexer()->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
+            $this->swapFlag = $parser->Literal();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Binary.php
+++ b/src/Query/Mysql/Binary.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Sarjono Mukti Aji <me@simukti.net>
@@ -14,18 +14,18 @@ class Binary extends FunctionNode
 {
     private $stringPrimary;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->stringPrimary = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'BINARY('.$sqlWalker->walkSimpleArithmeticExpression($this->stringPrimary).')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->stringPrimary = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/BitCount.php
+++ b/src/Query/Mysql/BitCount.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class BitCount extends FunctionNode
 {
@@ -21,11 +21,11 @@ class BitCount extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/BitXor.php
+++ b/src/Query/Mysql/BitXor.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * "BIT_XOR" "(" ArithmeticPrimary "," ArithmeticPrimary ")"
@@ -25,13 +25,13 @@ class BitXor extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->firstArithmetic = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->secondArithmetic = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Cast.php
+++ b/src/Query/Mysql/Cast.php
@@ -5,10 +5,10 @@ namespace DoctrineExtensions\Query\Mysql;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * "CAST" "(" "$fieldIdentifierExpression" "AS" "$castingTypeExpression" ")"
@@ -23,44 +23,6 @@ class Cast extends FunctionNode
 
     protected string $castingTypeExpression;
 
-    /**
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->fieldIdentifierExpression = $parser->SimpleArithmeticExpression();
-
-        $parser->match(Lexer::T_AS);
-        $parser->match(Lexer::T_IDENTIFIER);
-
-        $type = $parser->getLexer()->token->value;
-
-        if ($parser->getLexer()->isNextToken(Lexer::T_OPEN_PARENTHESIS)) {
-            $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-            $parameter = $parser->Literal();
-            $parameters = [$parameter->value];
-
-            if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-                while ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-                    $parser->match(Lexer::T_COMMA);
-                    $parameter = $parser->Literal();
-                    $parameters[] = $parameter->value;
-                }
-            }
-
-            $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-            $type .= '('.implode(', ', $parameters).')';
-        }
-
-        $this->castingTypeExpression = $type;
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -68,5 +30,43 @@ class Cast extends FunctionNode
             $sqlWalker->walkSimpleArithmeticExpression($this->fieldIdentifierExpression),
             $this->castingTypeExpression
         );
+    }
+
+    /**
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->fieldIdentifierExpression = $parser->SimpleArithmeticExpression();
+
+        $parser->match(TokenType::T_AS);
+        $parser->match(TokenType::T_IDENTIFIER);
+
+        $type = $parser->getLexer()->token->value;
+
+        if ($parser->getLexer()->isNextToken(TokenType::T_OPEN_PARENTHESIS)) {
+            $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+            $parameter = $parser->Literal();
+            $parameters = [$parameter->value];
+
+            if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+                while ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+                    $parser->match(TokenType::T_COMMA);
+                    $parameter = $parser->Literal();
+                    $parameters[] = $parameter->value;
+                }
+            }
+
+            $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+            $type .= '('.implode(', ', $parameters).')';
+        }
+
+        $this->castingTypeExpression = $type;
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Ceil.php
+++ b/src/Query/Mysql/Ceil.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Ceil extends FunctionNode
 {
@@ -18,11 +18,11 @@ class Ceil extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/CharLength.php
+++ b/src/Query/Mysql/CharLength.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Metod <metod@simpel.si>
@@ -21,11 +21,11 @@ class CharLength extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->expr1 = $parser->ArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Collate.php
+++ b/src/Query/Mysql/Collate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/en/charset-collate.html
@@ -23,23 +23,6 @@ class Collate extends FunctionNode
      */
     public $collation = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->stringPrimary = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_COMMA);
-        $parser->match(Lexer::T_IDENTIFIER);
-
-        $lexer = $parser->getLexer();
-
-        $this->collation = $lexer->token->value;
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     /**
      * @param SqlWalker $sqlWalker
      * @return string
@@ -47,5 +30,22 @@ class Collate extends FunctionNode
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf('%s COLLATE %s', $sqlWalker->walkStringPrimary($this->stringPrimary), $this->collation);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->stringPrimary = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_COMMA);
+        $parser->match(TokenType::T_IDENTIFIER);
+
+        $lexer = $parser->getLexer();
+
+        $this->collation = $lexer->token->value;
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/ConcatWs.php
+++ b/src/Query/Mysql/ConcatWs.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andrew Mackrodt <andrew@ajmm.org>
@@ -15,45 +15,6 @@ class ConcatWs extends FunctionNode
     private $values = [];
 
     private $notEmpty = false;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        // Add the concat separator to the values array.
-        $this->values[] = $parser->ArithmeticExpression();
-
-        // Add the rest of the strings to the values array. CONCAT_WS must
-        // be used with at least 2 strings not including the separator.
-
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 3 || $lexer->lookahead->type == Lexer::T_COMMA) {
-            $parser->match(Lexer::T_COMMA);
-            $peek = $lexer->glimpse();
-
-            $this->values[] = $peek->value == '('
-                    ? $parser->FunctionDeclaration()
-                    : $parser->ArithmeticExpression();
-        }
-
-        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead->value)) {
-                case 'notempty':
-                    $parser->match(Lexer::T_IDENTIFIER);
-                    $this->notEmpty = true;
-
-                    break;
-                default: // Identifier not recognized (causes exception).
-                    $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-
-                    break;
-            }
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -82,5 +43,44 @@ class ConcatWs extends FunctionNode
 
         // Return the joined query.
         return implode('', $queryBuilder);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        // Add the concat separator to the values array.
+        $this->values[] = $parser->ArithmeticExpression();
+
+        // Add the rest of the strings to the values array. CONCAT_WS must
+        // be used with at least 2 strings not including the separator.
+
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 3 || $lexer->lookahead->type == TokenType::T_COMMA) {
+            $parser->match(TokenType::T_COMMA);
+            $peek = $lexer->glimpse();
+
+            $this->values[] = $peek->value == '('
+                    ? $parser->FunctionDeclaration()
+                    : $parser->ArithmeticExpression();
+        }
+
+        while ($lexer->lookahead->type == TokenType::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
+                case 'notempty':
+                    $parser->match(TokenType::T_IDENTIFIER);
+                    $this->notEmpty = true;
+
+                    break;
+                default: // Identifier not recognized (causes exception).
+                    $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+
+                    break;
+            }
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Conv.php
+++ b/src/Query/Mysql/Conv.php
@@ -3,10 +3,10 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @example SELECT CONV(111,2,10);
@@ -33,19 +33,19 @@ class Conv extends FunctionNode
     /**
      * @throws QueryException
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->string = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->fromBase = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->toBase = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/ConvertTz.php
+++ b/src/Query/Mysql/ConvertTz.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/en/date-and-time-functions.html#function_convert-tz
@@ -36,16 +36,16 @@ class ConvertTz extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->dateExpression = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->fromTz = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->toTz = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Cos.php
+++ b/src/Query/Mysql/Cos.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Cos extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Cos extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Cot.php
+++ b/src/Query/Mysql/Cot.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Cot extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Cot extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/CountIf.php
+++ b/src/Query/Mysql/CountIf.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andrew Mackrodt <andrew@ajmm.org>
@@ -18,33 +18,6 @@ class CountIf extends FunctionNode
 
     private $inverse = false;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr1 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->expr2 = $parser->ArithmeticExpression();
-
-        $lexer = $parser->getLexer();
-
-        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead->value)) {
-                case 'inverse':
-                    $parser->match(Lexer::T_IDENTIFIER);
-                    $this->inverse = true;
-
-                    break;
-                default: // Identifier not recognized (causes exception).
-                    $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-
-                    break;
-            }
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -53,5 +26,32 @@ class CountIf extends FunctionNode
             $sqlWalker->walkArithmeticPrimary($this->expr2),
             !$this->inverse ? '1 ELSE NULL' : 'NULL ELSE 1'
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr1 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->expr2 = $parser->ArithmeticExpression();
+
+        $lexer = $parser->getLexer();
+
+        while ($lexer->lookahead->type == TokenType::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
+                case 'inverse':
+                    $parser->match(TokenType::T_IDENTIFIER);
+                    $this->inverse = true;
+
+                    break;
+                default: // Identifier not recognized (causes exception).
+                    $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+
+                    break;
+            }
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Crc32.php
+++ b/src/Query/Mysql/Crc32.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
@@ -23,11 +23,11 @@ class Crc32 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->stringPrimary = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Date.php
+++ b/src/Query/Mysql/Date.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Lacey <steve@steve.ly>
@@ -21,11 +21,11 @@ class Date extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DateAdd.php
+++ b/src/Query/Mysql/DateAdd.php
@@ -3,10 +3,10 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class DateAdd extends FunctionNode
 {
@@ -39,22 +39,6 @@ class DateAdd extends FunctionNode
         'YEAR_MONTH',
     ];
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->firstDateExpression = $parser->ArithmeticFactor();
-
-        $parser->match(Lexer::T_COMMA);
-        $this->intervalExpression = $parser->ArithmeticFactor();
-
-        $parser->match(Lexer::T_COMMA);
-        $this->unit = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         $unit = strtoupper(is_string($this->unit) ? $this->unit : $this->unit->value);
@@ -66,6 +50,22 @@ class DateAdd extends FunctionNode
         return 'DATE_ADD(' .
             $sqlWalker->walkArithmeticTerm($this->firstDateExpression) . ', INTERVAL ' .
             $sqlWalker->walkArithmeticTerm($this->intervalExpression) . ' ' . $unit .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->firstDateExpression = $parser->ArithmeticFactor();
+
+        $parser->match(TokenType::T_COMMA);
+        $this->intervalExpression = $parser->ArithmeticFactor();
+
+        $parser->match(TokenType::T_COMMA);
+        $this->unit = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DateDiff.php
+++ b/src/Query/Mysql/DateDiff.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class DateDiff extends FunctionNode
 {
@@ -13,21 +13,21 @@ class DateDiff extends FunctionNode
 
     public $secondDateExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->firstDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->secondDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DATEDIFF(' .
             $sqlWalker->walkArithmeticTerm($this->firstDateExpression) . ', ' .
             $sqlWalker->walkArithmeticTerm($this->secondDateExpression) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->firstDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->secondDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DateFormat.php
+++ b/src/Query/Mysql/DateFormat.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Lacey <steve@steve.ly>
@@ -16,21 +16,21 @@ class DateFormat extends FunctionNode
 
     public $patternExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateExpression = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->patternExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DATE_FORMAT(' .
             $this->dateExpression->dispatch($sqlWalker) . ', ' .
             $this->patternExpression->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateExpression = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->patternExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Day.php
+++ b/src/Query/Mysql/Day.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Rafael Kassner <kassner@gmail.com>
@@ -22,11 +22,11 @@ class Day extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DayName.php
+++ b/src/Query/Mysql/DayName.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Lacey <steve@steve.ly>
@@ -21,11 +21,11 @@ class DayName extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DayOfWeek.php
+++ b/src/Query/Mysql/DayOfWeek.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class DayOfWeek extends FunctionNode
 {
@@ -18,11 +18,11 @@ class DayOfWeek extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/DayOfYear.php
+++ b/src/Query/Mysql/DayOfYear.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class DayOfYear extends FunctionNode
 {
@@ -28,11 +28,11 @@ class DayOfYear extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Degrees.php
+++ b/src/Query/Mysql/Degrees.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Degrees extends FunctionNode
 {
@@ -22,11 +22,11 @@ class Degrees extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Div.php
+++ b/src/Query/Mysql/Div.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/en/arithmetic-functions.html#operator_div
@@ -38,15 +38,15 @@ class Div extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->dividend = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->divisor = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Exp.php
+++ b/src/Query/Mysql/Exp.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Exp extends FunctionNode
 {
@@ -20,9 +20,9 @@ class Exp extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Extract.php
+++ b/src/Query/Mysql/Extract.php
@@ -2,10 +2,10 @@
 
 namespace DoctrineExtensions\Query\Mysql;
 
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Ahwalian Masykur <ahwalian@gmail.com>
@@ -16,21 +16,6 @@ class Extract extends DateAdd
 
     public $unit = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $parser->match(Lexer::T_IDENTIFIER);
-        $lexer = $parser->getLexer();
-        $this->unit = $lexer->token->value;
-
-        $parser->match(Lexer::T_IDENTIFIER);
-        $this->date = $parser->ArithmeticPrimary();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         $unit = strtoupper($this->unit);
@@ -39,5 +24,20 @@ class Extract extends DateAdd
         }
 
         return 'EXTRACT(' . $unit . ' FROM '. $this->date->dispatch($sqlWalker) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $parser->match(TokenType::T_IDENTIFIER);
+        $lexer = $parser->getLexer();
+        $this->unit = $lexer->token->value;
+
+        $parser->match(TokenType::T_IDENTIFIER);
+        $this->date = $parser->ArithmeticPrimary();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Field.php
+++ b/src/Query/Mysql/Field.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Jeremy Hicks <jeremy.hicks@gmail.com>
@@ -15,28 +15,6 @@ class Field extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        // Do the field.
-        $this->field = $parser->ArithmeticPrimary();
-
-        // Add the strings to the values array. FIELD must
-        // be used with at least 1 string not including the field.
-
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticPrimary();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -57,5 +35,27 @@ class Field extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        // Do the field.
+        $this->field = $parser->ArithmeticPrimary();
+
+        // Add the strings to the values array. FIELD must
+        // be used with at least 1 string not including the field.
+
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/FindInSet.php
+++ b/src/Query/Mysql/FindInSet.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class FindInSet extends FunctionNode
 {
@@ -13,21 +13,21 @@ class FindInSet extends FunctionNode
 
     public $haystack = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->needle = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->haystack = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'FIND_IN_SET(' .
             $this->needle->dispatch($sqlWalker) . ', ' .
             $this->haystack->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->needle = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->haystack = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Floor.php
+++ b/src/Query/Mysql/Floor.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Floor extends FunctionNode
 {
@@ -18,11 +18,11 @@ class Floor extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Format.php
+++ b/src/Query/Mysql/Format.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Wally Noveno <wally.noveno@gmail.com>
@@ -16,21 +16,21 @@ class Format extends FunctionNode
 
     public $patternExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->numberExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->patternExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'FORMAT(' .
             $this->numberExpression->dispatch($sqlWalker) . ', ' .
             $this->patternExpression->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->numberExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->patternExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/FromBase64.php
+++ b/src/Query/Mysql/FromBase64.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * "FROM_BASE64" "(" "$fieldIdentifierExpression" ")"
@@ -18,16 +18,16 @@ class FromBase64 extends FunctionNode
 {
     public $field = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'FROM_BASE64(' . $this->field->dispatch($sqlWalker) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/FromUnixtime.php
+++ b/src/Query/Mysql/FromUnixtime.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Nima S <nimasdj@yahoo.com>
@@ -33,17 +33,17 @@ class FromUnixtime extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->firstExpression = $parser->ArithmeticPrimary();
 
         // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
+        if (TokenType::T_COMMA === $lexer->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
             $this->secondExpression = $parser->ArithmeticPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Greatest.php
+++ b/src/Query/Mysql/Greatest.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -16,25 +16,6 @@ class Greatest extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -59,5 +40,24 @@ class Greatest extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Hex.php
+++ b/src/Query/Mysql/Hex.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Hex extends FunctionNode
 {
@@ -18,11 +18,11 @@ class Hex extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Hour.php
+++ b/src/Query/Mysql/Hour.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Dawid Nowak <macdada@mmg.pl>
@@ -21,11 +21,11 @@ class Hour extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IfElse.php
+++ b/src/Query/Mysql/IfElse.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andrew Mackrodt <andrew@ajmm.org>
@@ -13,30 +13,6 @@ use Doctrine\ORM\Query\SqlWalker;
 class IfElse extends FunctionNode
 {
     private $expr = [];
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr[] = $parser->ConditionalExpression();
-
-        $parser->match(Lexer::T_COMMA);
-        if ($parser->getLexer()->isNextToken(Lexer::T_NULL)) {
-            $parser->match(Lexer::T_NULL);
-            $this->expr[] = null;
-        } else {
-            $this->expr[] = $parser->ArithmeticExpression();
-        }
-        $parser->match(Lexer::T_COMMA);
-        if ($parser->getLexer()->isNextToken(Lexer::T_NULL)) {
-            $parser->match(Lexer::T_NULL);
-            $this->expr[] = null;
-        } else {
-            $this->expr[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -46,5 +22,29 @@ class IfElse extends FunctionNode
             $this->expr[1] !== null ? $sqlWalker->walkArithmeticPrimary($this->expr[1]) : 'NULL',
             $this->expr[2] !== null ? $sqlWalker->walkArithmeticPrimary($this->expr[2]) : 'NULL'
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr[] = $parser->ConditionalExpression();
+
+        $parser->match(TokenType::T_COMMA);
+        if ($parser->getLexer()->isNextToken(TokenType::T_NULL)) {
+            $parser->match(TokenType::T_NULL);
+            $this->expr[] = null;
+        } else {
+            $this->expr[] = $parser->ArithmeticExpression();
+        }
+        $parser->match(TokenType::T_COMMA);
+        if ($parser->getLexer()->isNextToken(TokenType::T_NULL)) {
+            $parser->match(TokenType::T_NULL);
+            $this->expr[] = null;
+        } else {
+            $this->expr[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IfNull.php
+++ b/src/Query/Mysql/IfNull.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andrew Mackrodt <andrew@ajmm.org>
@@ -16,20 +16,20 @@ class IfNull extends FunctionNode
 
     private $expr2;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr1 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->expr2 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'IFNULL('
             .$sqlWalker->walkArithmeticPrimary($this->expr1). ', '
             .$sqlWalker->walkArithmeticPrimary($this->expr2).')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr1 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->expr2 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Inet6Aton.php
+++ b/src/Query/Mysql/Inet6Aton.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Inet6Aton extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class Inet6Aton extends FunctionNode
     {
         return 'INET6_ATON('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Inet6Ntoa.php
+++ b/src/Query/Mysql/Inet6Ntoa.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Inet6Ntoa extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class Inet6Ntoa extends FunctionNode
     {
         return 'INET6_NTOA('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/InetAton.php
+++ b/src/Query/Mysql/InetAton.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class InetAton extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class InetAton extends FunctionNode
     {
         return 'INET_ATON('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/InetNtoa.php
+++ b/src/Query/Mysql/InetNtoa.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class InetNtoa extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class InetNtoa extends FunctionNode
     {
         return 'INET_NTOA('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Instr.php
+++ b/src/Query/Mysql/Instr.php
@@ -2,26 +2,16 @@
 
 namespace DoctrineExtensions\Query\Mysql;
 
-use  Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use  Doctrine\ORM\Query\Lexer;
-use  Doctrine\ORM\Query\Parser;
-use  Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Instr extends FunctionNode
 {
     public $originalString = null;
 
     public $subString = null;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->originalString = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->subString = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -30,5 +20,15 @@ class Instr extends FunctionNode
             $this->originalString->dispatch($sqlWalker),
             $this->subString->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->originalString = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->subString = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IsIpv4.php
+++ b/src/Query/Mysql/IsIpv4.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class IsIpv4 extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class IsIpv4 extends FunctionNode
     {
         return 'IS_IPV4('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IsIpv4Compat.php
+++ b/src/Query/Mysql/IsIpv4Compat.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class IsIpv4Compat extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class IsIpv4Compat extends FunctionNode
     {
         return 'IS_IPV4_COMPAT('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IsIpv4Mapped.php
+++ b/src/Query/Mysql/IsIpv4Mapped.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class IsIpv4Mapped extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class IsIpv4Mapped extends FunctionNode
     {
         return 'IS_IPV4_MAPPED('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/IsIpv6.php
+++ b/src/Query/Mysql/IsIpv6.php
@@ -4,27 +4,14 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class IsIpv6 extends FunctionNode
 {
     public $valueExpression = null;
-
-    /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->valueExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -35,10 +22,23 @@ class IsIpv6 extends FunctionNode
     {
         return 'IS_IPV6('
             . (
-                $this->valueExpression instanceof Node
+            $this->valueExpression instanceof Node
                 ? $this->valueExpression->dispatch($sqlWalker)
                 : "'" . $this->valueExpression . "'"
             )
             .')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->valueExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/JsonContains.php
+++ b/src/Query/Mysql/JsonContains.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class JsonContains extends FunctionNode
 {
@@ -14,26 +14,6 @@ class JsonContains extends FunctionNode
     protected $candidate;
 
     protected $path;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->target = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_COMMA);
-
-        $this->candidate = $parser->StringPrimary();
-
-        if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
-
-            $this->path = $parser->StringPrimary();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -47,5 +27,25 @@ class JsonContains extends FunctionNode
         }
 
         return sprintf('JSON_CONTAINS(%s, %s)', $target, $candidate);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->target = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_COMMA);
+
+        $this->candidate = $parser->StringPrimary();
+
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
+
+            $this->path = $parser->StringPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/JsonDepth.php
+++ b/src/Query/Mysql/JsonDepth.php
@@ -3,26 +3,26 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class JsonDepth extends FunctionNode
 {
     protected $target;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->target = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf('JSON_DEPTH(%s)', $sqlWalker->walkStringPrimary($this->target));
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->target = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/JsonExtract.php
+++ b/src/Query/Mysql/JsonExtract.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class JsonExtract extends FunctionNode
 {
@@ -13,24 +13,24 @@ class JsonExtract extends FunctionNode
 
     protected $path;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->target = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_COMMA);
-        $this->path = $parser->StringPrimary();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         $target = $sqlWalker->walkStringPrimary($this->target);
         $path = $sqlWalker->walkStringPrimary($this->path);
 
         return sprintf('JSON_EXTRACT(%s, %s)', $target, $path);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->target = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_COMMA);
+        $this->path = $parser->StringPrimary();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/JsonLength.php
+++ b/src/Query/Mysql/JsonLength.php
@@ -3,31 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class JsonLength extends FunctionNode
 {
     protected $target;
 
     protected $path;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->target = $parser->StringPrimary();
-
-        if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
-
-            $this->path = $parser->StringPrimary();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -40,5 +24,21 @@ class JsonLength extends FunctionNode
         }
 
         return sprintf('JSON_LENGTH(%s)', $target);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->target = $parser->StringPrimary();
+
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
+
+            $this->path = $parser->StringPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/JsonUnquote.php
+++ b/src/Query/Mysql/JsonUnquote.php
@@ -3,26 +3,26 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class JsonUnquote extends FunctionNode
 {
     protected $expression;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
         $expression = $sqlWalker->walkStringPrimary($this->expression);
 
         return sprintf('JSON_UNQUOTE(%s)', $expression);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Lag.php
+++ b/src/Query/Mysql/Lag.php
@@ -6,9 +6,9 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Lag extends FunctionNode
 {
@@ -37,18 +37,18 @@ class Lag extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->aggregateExpression = $parser->StringExpression();
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
-            $parser->match(Lexer::T_COMMA);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
+            $parser->match(TokenType::T_COMMA);
             $this->offset = $parser->ArithmeticPrimary();
         }
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
-            $parser->match(Lexer::T_COMMA);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
+            $parser->match(TokenType::T_COMMA);
             $this->defaultValue = $parser->SimpleArithmeticExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/LastDay.php
+++ b/src/Query/Mysql/LastDay.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Rafael Kassner <kassner@gmail.com>
@@ -22,11 +22,11 @@ class LastDay extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/LastInsertId.php
+++ b/src/Query/Mysql/LastInsertId.php
@@ -6,9 +6,9 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class LastInsertId extends FunctionNode
 {
@@ -25,12 +25,12 @@ class LastInsertId extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
             $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Lead.php
+++ b/src/Query/Mysql/Lead.php
@@ -6,9 +6,9 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Lead extends FunctionNode
 {
@@ -37,18 +37,18 @@ class Lead extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->aggregateExpression = $parser->StringExpression();
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
-            $parser->match(Lexer::T_COMMA);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
+            $parser->match(TokenType::T_COMMA);
             $this->offset = $parser->ArithmeticPrimary();
         }
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
-            $parser->match(Lexer::T_COMMA);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
+            $parser->match(TokenType::T_COMMA);
             $this->defaultValue = $parser->SimpleArithmeticExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Least.php
+++ b/src/Query/Mysql/Least.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -15,25 +15,6 @@ class Least extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -58,5 +39,24 @@ class Least extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Log.php
+++ b/src/Query/Mysql/Log.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Log extends FunctionNode
 {
@@ -20,9 +20,9 @@ class Log extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Log10.php
+++ b/src/Query/Mysql/Log10.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Log10 extends FunctionNode
 {
@@ -20,9 +20,9 @@ class Log10 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Log2.php
+++ b/src/Query/Mysql/Log2.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Log2 extends FunctionNode
 {
@@ -20,9 +20,9 @@ class Log2 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Lpad.php
+++ b/src/Query/Mysql/Lpad.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Giulia Santoiemma <giuliaries@gmail.com>
@@ -18,24 +18,24 @@ class Lpad extends FunctionNode
 
     public $padstring = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->string = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->length = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->padstring = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'LPAD(' .
-        $this->string->dispatch($sqlWalker) . ', ' .
-        $this->length->dispatch($sqlWalker) . ', ' .
-        $this->padstring->dispatch($sqlWalker) .
-        ')';
+            $this->string->dispatch($sqlWalker) . ', ' .
+            $this->length->dispatch($sqlWalker) . ', ' .
+            $this->padstring->dispatch($sqlWalker) .
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->string = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->length = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->padstring = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/MakeDate.php
+++ b/src/Query/Mysql/MakeDate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class MakeDate extends FunctionNode
 {
@@ -13,21 +13,21 @@ class MakeDate extends FunctionNode
 
     public $dayOfYear = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->year = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->dayOfYear = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'MAKEDATE('.
             $sqlWalker->walkArithmeticPrimary($this->year).', '.
             $sqlWalker->walkArithmeticPrimary($this->dayOfYear).
             ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->year = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->dayOfYear = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Md5.php
+++ b/src/Query/Mysql/Md5.php
@@ -3,10 +3,10 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andreas Gallien <gallien@seleos.de>
@@ -25,11 +25,11 @@ class Md5 extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->stringPrimary = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Minute.php
+++ b/src/Query/Mysql/Minute.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Martin Štekl <martin.stekl@gmail.com>
@@ -21,11 +21,11 @@ class Minute extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Mod.php
+++ b/src/Query/Mysql/Mod.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/en/arithmetic-functions.html#operator_mod
@@ -32,15 +32,15 @@ class Mod extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->dividend = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->divisor = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Month.php
+++ b/src/Query/Mysql/Month.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Rafael Kassner <kassner@gmail.com>
@@ -22,11 +22,11 @@ class Month extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/MonthName.php
+++ b/src/Query/Mysql/MonthName.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Lacey <steve@steve.ly>
@@ -21,11 +21,11 @@ class MonthName extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Now.php
+++ b/src/Query/Mysql/Now.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Now extends FunctionNode
 {
@@ -16,8 +16,8 @@ class Now extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/NullIf.php
+++ b/src/Query/Mysql/NullIf.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andrew Mackrodt <andrew@ajmm.org>
@@ -16,16 +16,6 @@ class NullIf extends FunctionNode
 
     private $expr2;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr1 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->expr2 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -33,5 +23,15 @@ class NullIf extends FunctionNode
             $sqlWalker->walkArithmeticPrimary($this->expr1),
             $sqlWalker->walkArithmeticPrimary($this->expr2)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr1 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->expr2 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Over.php
+++ b/src/Query/Mysql/Over.php
@@ -5,9 +5,9 @@ namespace DoctrineExtensions\Query\Mysql;
 use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\OrderByClause;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Over extends FunctionNode
 {
@@ -28,13 +28,13 @@ class Over extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->arithmeticExpression = $parser->ArithmeticExpression();
-        if (!$lexer->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
-            $parser->match(Lexer::T_COMMA);
+        if (!$lexer->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
+            $parser->match(TokenType::T_COMMA);
             $this->orderByClause = $parser->OrderByClause();
         }
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/PeriodDiff.php
+++ b/src/Query/Mysql/PeriodDiff.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class PeriodDiff extends FunctionNode
 {
@@ -13,21 +13,21 @@ class PeriodDiff extends FunctionNode
 
     public $secondDateExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->firstDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->secondDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'PERIOD_DIFF(' .
             $sqlWalker->walkArithmeticTerm($this->firstDateExpression) . ', ' .
             $sqlWalker->walkArithmeticTerm($this->secondDateExpression) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->firstDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->secondDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Pi.php
+++ b/src/Query/Mysql/Pi.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Pi extends FunctionNode
 {
@@ -18,8 +18,8 @@ class Pi extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Point.php
+++ b/src/Query/Mysql/Point.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/8.0/en/gis-class-point.html
@@ -27,12 +27,12 @@ class Point extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->latitude = $parser->ArithmeticPrimary();
         $this->longitude = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Power.php
+++ b/src/Query/Mysql/Power.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Power extends FunctionNode
 {
@@ -21,13 +21,13 @@ class Power extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->power = $parser->ArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Quarter.php
+++ b/src/Query/Mysql/Quarter.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Martin Štekl <martin.stekl@gmail.com>
@@ -21,11 +21,11 @@ class Quarter extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Radians.php
+++ b/src/Query/Mysql/Radians.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Radians extends FunctionNode
 {
@@ -22,11 +22,11 @@ class Radians extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Rand.php
+++ b/src/Query/Mysql/Rand.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Rand extends FunctionNode
 {
@@ -27,13 +27,13 @@ class Rand extends FunctionNode
     public function parse(Parser $parser): void
     {
         $lexer = $parser->getLexer();
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
-        if (Lexer::T_CLOSE_PARENTHESIS !== $lexer->lookahead->type) {
+        if (TokenType::T_CLOSE_PARENTHESIS !== $lexer->lookahead->type) {
             $this->expression = $parser->SimpleArithmeticExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Regexp.php
+++ b/src/Query/Mysql/Regexp.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Regexp extends FunctionNode
 {
@@ -13,18 +13,18 @@ class Regexp extends FunctionNode
 
     public $regexp = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->value = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->regexp = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return '(' . $this->value->dispatch($sqlWalker) . ' REGEXP ' . $this->regexp->dispatch($sqlWalker) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->value = $parser->StringPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->regexp = $parser->StringExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/RegexpReplace.php
+++ b/src/Query/Mysql/RegexpReplace.php
@@ -3,7 +3,7 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @example SELECT REGEXP_REPLACE(string, search, replace)
@@ -17,22 +17,22 @@ class RegexpReplace extends FunctionNode
 
     private $replace;
 
-    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker): string
     {
         return 'REGEXP_REPLACE('.$this->string->dispatch($sqlWalker).', '.$this->search->dispatch($sqlWalker).', '.$this->replace->dispatch($sqlWalker).')';
     }
 
-    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    public function parse(\Doctrine\ORM\Query\Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->string = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->search = $parser->StringExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->replace = $parser->StringExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/RegexpSubStr.php
+++ b/src/Query/Mysql/RegexpSubStr.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @example SELECT REGEXP_SUBSTR('abc def ghi', '[a-z]+');
@@ -27,15 +27,15 @@ class RegexpSubStr extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->field = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->regex = $parser->StringExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Replace.php
+++ b/src/Query/Mysql/Replace.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Jarek Kostrz <jkostrz@gmail.com>
@@ -18,24 +18,24 @@ class Replace extends FunctionNode
 
     public $subject = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->subject = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->search = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->replace = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'REPLACE(' .
             $this->subject->dispatch($sqlWalker) . ', ' .
             $this->search->dispatch($sqlWalker) . ', ' .
             $this->replace->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->subject = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->search = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->replace = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Round.php
+++ b/src/Query/Mysql/Round.php
@@ -3,31 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Round extends FunctionNode
 {
     private $firstExpression = null;
 
     private $secondExpression = null;
-
-    public function parse(Parser $parser): void
-    {
-        $lexer = $parser->getLexer();
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->firstExpression = $parser->SimpleArithmeticExpression();
-
-        // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
-            $this->secondExpression = $parser->ArithmeticPrimary();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -41,5 +25,21 @@ class Round extends FunctionNode
         }
 
         return 'ROUND(' . $this->firstExpression->dispatch($sqlWalker) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $lexer = $parser->getLexer();
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->firstExpression = $parser->SimpleArithmeticExpression();
+
+        // parse second parameter if available
+        if (TokenType::T_COMMA === $lexer->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
+            $this->secondExpression = $parser->ArithmeticPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Rpad.php
+++ b/src/Query/Mysql/Rpad.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Giulia Santoiemma <giuliaries@gmail.com>
@@ -18,24 +18,24 @@ class Rpad extends FunctionNode
 
     public $padstring = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->string = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->length = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->padstring = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'RPAD(' .
-        $this->string->dispatch($sqlWalker) . ', ' .
-        $this->length->dispatch($sqlWalker) . ', ' .
-        $this->padstring->dispatch($sqlWalker) .
-        ')';
+            $this->string->dispatch($sqlWalker) . ', ' .
+            $this->length->dispatch($sqlWalker) . ', ' .
+            $this->padstring->dispatch($sqlWalker) .
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->string = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->length = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->padstring = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/SecToTime.php
+++ b/src/Query/Mysql/SecToTime.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @example SELECT SEC_TO_TIME(2378);
@@ -23,11 +23,11 @@ class SecToTime extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->time = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Second.php
+++ b/src/Query/Mysql/Second.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Martin Štekl <martin.stekl@gmail.com>
@@ -21,11 +21,11 @@ class Second extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Sha1.php
+++ b/src/Query/Mysql/Sha1.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andreas Gallien <gallien@seleos.de>
@@ -23,11 +23,11 @@ class Sha1 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->stringPrimary = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Sha2.php
+++ b/src/Query/Mysql/Sha2.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andreas Gallien <gallien@seleos.de>
@@ -27,13 +27,13 @@ class Sha2 extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->stringPrimary = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->simpleArithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Sin.php
+++ b/src/Query/Mysql/Sin.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Sin extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Sin extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Soundex.php
+++ b/src/Query/Mysql/Soundex.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Tauber <taubers@gmail.com>
@@ -21,11 +21,11 @@ class Soundex extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->stringPrimary = $parser->StringPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/StDistanceSphere.php
+++ b/src/Query/Mysql/StDistanceSphere.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://dev.mysql.com/doc/refman/8.0/en/spatial-convenience-functions.html#function_st-distance-sphere
@@ -27,13 +27,13 @@ class StDistanceSphere extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->origin = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->remote = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Std.php
+++ b/src/Query/Mysql/Std.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Toni Uebernickel <tuebernickel@gmail.com>
@@ -21,11 +21,11 @@ class Std extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/StdDev.php
+++ b/src/Query/Mysql/StdDev.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Joachim Schirrmacher <j.schirrmacher@dilab.co>
@@ -21,11 +21,11 @@ class StdDev extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/StrToDate.php
+++ b/src/Query/Mysql/StrToDate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class StrToDate extends FunctionNode
 {
@@ -13,21 +13,21 @@ class StrToDate extends FunctionNode
 
     public $dateFormat = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateString = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->dateFormat = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'STR_TO_DATE(' .
             $this->dateString->dispatch($sqlWalker) . ', ' .
             $this->dateFormat->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateString = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->dateFormat = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/SubstringIndex.php
+++ b/src/Query/Mysql/SubstringIndex.php
@@ -2,10 +2,10 @@
 
 namespace DoctrineExtensions\Query\Mysql;
 
-use  Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use  Doctrine\ORM\Query\Lexer;
-use  Doctrine\ORM\Query\Parser;
-use  Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class SubstringIndex extends FunctionNode
 {
@@ -15,18 +15,6 @@ class SubstringIndex extends FunctionNode
 
     public $count = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->string = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->delimiter = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->count = $parser->ArithmeticFactor();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -35,5 +23,17 @@ class SubstringIndex extends FunctionNode
             $this->delimiter->dispatch($sqlWalker),
             $this->count->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->string = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->delimiter = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->count = $parser->ArithmeticFactor();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Tan.php
+++ b/src/Query/Mysql/Tan.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Tan extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Tan extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Time.php
+++ b/src/Query/Mysql/Time.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Steve Lacey <steve@steve.ly>
@@ -22,11 +22,11 @@ class Time extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->time = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/TimeDiff.php
+++ b/src/Query/Mysql/TimeDiff.php
@@ -3,25 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class TimeDiff extends FunctionNode
 {
     public $firstDateExpression = null;
 
     public $secondDateExpression = null;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->firstDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->secondDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -30,5 +20,15 @@ class TimeDiff extends FunctionNode
             $this->firstDateExpression->dispatch($sqlWalker),
             $this->secondDateExpression->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->firstDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->secondDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/TimeToSec.php
+++ b/src/Query/Mysql/TimeToSec.php
@@ -3,7 +3,7 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\TokenType;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
@@ -23,11 +23,11 @@ class TimeToSec extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->time = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/TimestampAdd.php
+++ b/src/Query/Mysql/TimestampAdd.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Alessandro Tagliapietra <tagliapietra.alessandro@gmail.com>
@@ -18,20 +18,6 @@ class TimestampAdd extends FunctionNode
 
     public $unit = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_IDENTIFIER);
-        $lexer = $parser->getLexer();
-        $this->unit = $lexer->token->value;
-        $parser->match(Lexer::T_COMMA);
-        $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->secondDatetimeExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -40,5 +26,19 @@ class TimestampAdd extends FunctionNode
             $this->firstDatetimeExpression->dispatch($sqlWalker),
             $this->secondDatetimeExpression->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $lexer = $parser->getLexer();
+        $this->unit = $lexer->token->value;
+        $parser->match(TokenType::T_COMMA);
+        $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->secondDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/TimestampDiff.php
+++ b/src/Query/Mysql/TimestampDiff.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Przemek Sobstel <przemek@sobstel.org>
@@ -18,20 +18,6 @@ class TimestampDiff extends FunctionNode
 
     public $unit = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_IDENTIFIER);
-        $lexer = $parser->getLexer();
-        $this->unit = $lexer->token->value;
-        $parser->match(Lexer::T_COMMA);
-        $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->secondDatetimeExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -40,5 +26,19 @@ class TimestampDiff extends FunctionNode
             $this->firstDatetimeExpression->dispatch($sqlWalker),
             $this->secondDatetimeExpression->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $lexer = $parser->getLexer();
+        $this->unit = $lexer->token->value;
+        $parser->match(TokenType::T_COMMA);
+        $this->firstDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->secondDatetimeExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Truncate.php
+++ b/src/Query/Mysql/Truncate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Evgeny Savich <jack.savich@gmail.com>
@@ -16,21 +16,21 @@ class Truncate extends FunctionNode
 
     public $patternExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->numberExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->patternExpression = $parser->SimpleArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'TRUNCATE(' .
             $this->numberExpression->dispatch($sqlWalker) . ', ' .
             $this->patternExpression->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->numberExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->patternExpression = $parser->SimpleArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Unhex.php
+++ b/src/Query/Mysql/Unhex.php
@@ -3,7 +3,7 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\TokenType;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
@@ -18,11 +18,11 @@ class Unhex extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/UnixTimestamp.php
+++ b/src/Query/Mysql/UnixTimestamp.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author      Rafael Kassner <kassner@gmail.com>
@@ -25,13 +25,13 @@ class UnixTimestamp extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
-        if (!$parser->getLexer()->isNextToken(Lexer::T_CLOSE_PARENTHESIS)) {
+        if (!$parser->getLexer()->isNextToken(TokenType::T_CLOSE_PARENTHESIS)) {
             $this->date = $parser->ArithmeticPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/UtcTimestamp.php
+++ b/src/Query/Mysql/UtcTimestamp.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author      Marius Krämer <marius@marius-kraemer.de>
@@ -19,8 +19,8 @@ class UtcTimestamp extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/UuidShort.php
+++ b/src/Query/Mysql/UuidShort.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class UuidShort extends FunctionNode
 {
@@ -18,8 +18,8 @@ class UuidShort extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/UuidToBin.php
+++ b/src/Query/Mysql/UuidToBin.php
@@ -3,30 +3,15 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class UuidToBin extends FunctionNode
 {
     public $stringUuid = null;
 
     public $swapFlag = null;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->stringUuid = $parser->ArithmeticPrimary();
-
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
-            $this->swapFlag = $parser->Literal();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -37,5 +22,20 @@ class UuidToBin extends FunctionNode
         $sql .= ')';
 
         return $sql;
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->stringUuid = $parser->ArithmeticPrimary();
+
+        if (TokenType::T_COMMA === $parser->getLexer()->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
+            $this->swapFlag = $parser->Literal();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Variance.php
+++ b/src/Query/Mysql/Variance.php
@@ -4,27 +4,27 @@ namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Variance extends FunctionNode
 {
     /** @var SimpleArithmeticExpression */
     protected $arithmeticExpression;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf('VARIANCE(%s)', $sqlWalker->walkSimpleArithmeticExpression($this->arithmeticExpression));
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->arithmeticExpression = $parser->SimpleArithmeticExpression();
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Week.php
+++ b/src/Query/Mysql/Week.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Rafael Kassner <kassner@gmail.com>
@@ -31,16 +31,16 @@ class Week extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
+        if (TokenType::T_COMMA === $parser->getLexer()->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
             $this->mode = $parser->Literal();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/WeekDay.php
+++ b/src/Query/Mysql/WeekDay.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Pavlo Cherniavskyi <ionafan2@gmail.com>
@@ -21,11 +21,11 @@ class WeekDay extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/WeekOfYear.php
+++ b/src/Query/Mysql/WeekOfYear.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class WeekOfYear extends FunctionNode
 {
@@ -18,11 +18,11 @@ class WeekOfYear extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/Year.php
+++ b/src/Query/Mysql/Year.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Rafael Kassner <kassner@gmail.com>
@@ -21,11 +21,11 @@ class Year extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/YearMonth.php
+++ b/src/Query/Mysql/YearMonth.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class YearMonth extends FunctionNode
 {
@@ -21,9 +21,9 @@ class YearMonth extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Mysql/YearWeek.php
+++ b/src/Query/Mysql/YearWeek.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Mysql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Michael Kimpton <mike@sketchthat.com>
@@ -29,16 +29,16 @@ class YearWeek extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
+        if (TokenType::T_COMMA === $parser->getLexer()->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
             $this->mode = $parser->Literal();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/MysqlWalker.php
+++ b/src/Query/MysqlWalker.php
@@ -9,7 +9,7 @@ class MysqlWalker extends SqlWalker
     /**
      * @inheritdoc
      */
-    public function walkSelectClause($selectClause): array|string
+    public function walkSelectClause($selectClause): string
     {
         $sql = parent::walkSelectClause($selectClause);
 

--- a/src/Query/Oracle/Ceil.php
+++ b/src/Query/Oracle/Ceil.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Jefferson Vantuir <jefferson.behling@gmail.com>
@@ -24,9 +24,9 @@ class Ceil extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->number = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Day.php
+++ b/src/Query/Oracle/Day.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Day extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Floor.php
+++ b/src/Query/Oracle/Floor.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Jefferson Vantuir <jefferson.behling@gmail.com>
@@ -24,9 +24,9 @@ class Floor extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->number = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Hour.php
+++ b/src/Query/Oracle/Hour.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Hour extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Listagg.php
+++ b/src/Query/Oracle/Listagg.php
@@ -5,9 +5,9 @@ namespace DoctrineExtensions\Query\Oracle;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\OrderByClause;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @link https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/LISTAGG.html#GUID-B6E50D8E-F467-425B-9436-F7F8BF38D466
@@ -33,47 +33,47 @@ class Listagg extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->listaggField = $parser->StringPrimary();
 
-        if ($lexer->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        if ($lexer->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->separator = $parser->StringExpression();
         }
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
 
-        if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'within') {
+        if (!$lexer->isNextToken(TokenType::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'within') {
             $parser->syntaxError('WITHIN GROUP');
         }
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_GROUP);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_GROUP);
 
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->orderBy = $parser->OrderByClause();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
 
-        if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+        if ($lexer->isNextToken(TokenType::T_IDENTIFIER)) {
             if (strtolower($lexer->lookahead->value) != 'over') {
                 $parser->syntaxError('OVER');
             }
-            $parser->match(Lexer::T_IDENTIFIER);
-            $parser->match(Lexer::T_OPEN_PARENTHESIS);
+            $parser->match(TokenType::T_IDENTIFIER);
+            $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
-            if (!$lexer->isNextToken(Lexer::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'partition') {
+            if (!$lexer->isNextToken(TokenType::T_IDENTIFIER) || strtolower($lexer->lookahead->value) != 'partition') {
                 $parser->syntaxError('PARTITION BY');
             }
-            $parser->match(Lexer::T_IDENTIFIER);
-            $parser->match(Lexer::T_BY);
+            $parser->match(TokenType::T_IDENTIFIER);
+            $parser->match(TokenType::T_BY);
 
             $this->partitionBy[] = $parser->StringPrimary();
 
-            while ($lexer->isNextToken(Lexer::T_COMMA)) {
-                $parser->match(Lexer::T_COMMA);
+            while ($lexer->isNextToken(TokenType::T_COMMA)) {
+                $parser->match(TokenType::T_COMMA);
                 $this->partitionBy[] = $parser->StringPrimary();
             }
 
-            $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+            $parser->match(TokenType::T_CLOSE_PARENTHESIS);
         }
     }
 

--- a/src/Query/Oracle/Minute.php
+++ b/src/Query/Oracle/Minute.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Minute extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Month.php
+++ b/src/Query/Oracle/Month.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Month extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Nvl.php
+++ b/src/Query/Oracle/Nvl.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -27,11 +27,11 @@ class Nvl extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Second.php
+++ b/src/Query/Oracle/Second.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Second extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/ToChar.php
+++ b/src/Query/Oracle/ToChar.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Cédric Bertolini <bertolini.cedric@me.com>
@@ -40,17 +40,17 @@ class ToChar extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->datetime = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->fmt = $parser->StringExpression();
 
-        if ($lexer->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        if ($lexer->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->nls = $parser->StringExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/ToDate.php
+++ b/src/Query/Oracle/ToDate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Mohammad ZeinEddin <mohammad@zeineddin.name>
@@ -27,11 +27,11 @@ class ToDate extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->fmt = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Trunc.php
+++ b/src/Query/Oracle/Trunc.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Mohammad ZeinEddin <mohammad@zeineddin.name>
@@ -43,15 +43,15 @@ class Trunc extends FunctionNode
     {
         $lexer = $parser->getLexer();
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticExpression();
 
-        if ($lexer->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        if ($lexer->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->fmt = $parser->StringExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Oracle/Year.php
+++ b/src/Query/Oracle/Year.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Oracle;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Andréia Bohner <andreiabohner@gmail.com>
@@ -24,9 +24,9 @@ class Year extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Age.php
+++ b/src/Query/Postgresql/Age.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Age extends FunctionNode
 {
@@ -20,11 +20,11 @@ class Age extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->date2 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/AtTimeZoneFunction.php
+++ b/src/Query/Postgresql/AtTimeZoneFunction.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * AtTimeZoneFunction ::= "AT_TIME_ZONE" "(" ArithmeticPrimary "," ArithmeticPrimary ")"
@@ -16,16 +16,6 @@ class AtTimeZoneFunction extends FunctionNode
 
     public $timezoneExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->timezoneExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -33,5 +23,15 @@ class AtTimeZoneFunction extends FunctionNode
             $this->dateExpression->dispatch($sqlWalker),
             $this->timezoneExpression->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->timezoneExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/CountFilterFunction.php
+++ b/src/Query/Postgresql/CountFilterFunction.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * CountFilterFunction ::= "COUNT_FILTER" "(" ArithmeticPrimary "," ArithmeticPrimary ")"
@@ -16,16 +16,6 @@ class CountFilterFunction extends FunctionNode
 
     public $whereExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->countExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->whereExpression = $parser->WhereClause();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return sprintf(
@@ -33,5 +23,15 @@ class CountFilterFunction extends FunctionNode
             $this->countExpression->dispatch($sqlWalker),
             $this->whereExpression->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->countExpression = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->whereExpression = $parser->WhereClause();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Date.php
+++ b/src/Query/Postgresql/Date.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Date extends FunctionNode
 {
@@ -18,11 +18,11 @@ class Date extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/DateFormat.php
+++ b/src/Query/Postgresql/DateFormat.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Silvio
@@ -16,21 +16,21 @@ class DateFormat extends FunctionNode
 
     public $patternExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateExpression = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->patternExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'TO_CHAR(' .
             $this->dateExpression->dispatch($sqlWalker) . ', ' .
             $this->patternExpression->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateExpression = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->patternExpression = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/DatePart.php
+++ b/src/Query/Postgresql/DatePart.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Geovani Roggeo
@@ -16,21 +16,21 @@ class DatePart extends FunctionNode
 
     public $dateFormat = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateString = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->dateFormat = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'DATE_PART(' .
             $this->dateString->dispatch($sqlWalker) . ', ' .
             $this->dateFormat->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateString = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->dateFormat = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/DateTrunc.php
+++ b/src/Query/Postgresql/DateTrunc.php
@@ -3,25 +3,15 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class DateTrunc extends FunctionNode
 {
     public $fieldText = null;
 
     public $fieldTimestamp = null;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->fieldText = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->fieldTimestamp = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -30,5 +20,15 @@ class DateTrunc extends FunctionNode
             $this->fieldText->dispatch($sqlWalker),
             $this->fieldTimestamp->dispatch($sqlWalker)
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->fieldText = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->fieldTimestamp = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Day.php
+++ b/src/Query/Postgresql/Day.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Day extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Day extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/ExtractFunction.php
+++ b/src/Query/Postgresql/ExtractFunction.php
@@ -5,10 +5,10 @@ namespace DoctrineExtensions\Query\Postgresql;
 use Doctrine\ORM\Query\AST\ASTException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\PathExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class ExtractFunction extends FunctionNode
 {
@@ -40,16 +40,16 @@ class ExtractFunction extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
-        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(TokenType::T_IDENTIFIER);
         $this->field = $parser->getLexer()->token->value;
 
-        $parser->match(Lexer::T_FROM);
+        $parser->match(TokenType::T_FROM);
 
         $this->value = $parser->ScalarExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Greatest.php
+++ b/src/Query/Postgresql/Greatest.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -17,25 +17,6 @@ class Greatest extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -60,5 +41,24 @@ class Greatest extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Hour.php
+++ b/src/Query/Postgresql/Hour.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Hour extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Hour extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Ilike.php
+++ b/src/Query/Postgresql/Ilike.php
@@ -5,10 +5,10 @@ namespace DoctrineExtensions\Query\Postgresql;
 use Doctrine\ORM\Query\AST\ASTException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Ilike extends FunctionNode
 {
@@ -19,28 +19,28 @@ class Ilike extends FunctionNode
     protected $query;
 
     /**
-     * @param Parser $parser
-     *
-     * @throws QueryException
-     */
-    public function parse(Parser $parser)
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->StringExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->query = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
-    /**
      * @param SqlWalker $sqlWalker
      *
      * @throws ASTException
      * @return string
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return '(' . $this->field->dispatch($sqlWalker) . ' ILIKE ' . $this->query->dispatch($sqlWalker) . ')';
+    }
+
+    /**
+     * @param Parser $parser
+     *
+     * @throws QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->StringExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->query = $parser->StringExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Least.php
+++ b/src/Query/Postgresql/Least.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -16,25 +16,6 @@ class Least extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -59,5 +40,24 @@ class Least extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Minute.php
+++ b/src/Query/Postgresql/Minute.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Minute extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Minute extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Month.php
+++ b/src/Query/Postgresql/Month.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Month extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Month extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/RegexpReplace.php
+++ b/src/Query/Postgresql/RegexpReplace.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @example SELECT REGEXP_REPLACE(string, search, replace)
@@ -26,15 +26,15 @@ class RegexpReplace extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->string = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->search = $parser->StringExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->replace = $parser->StringExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Second.php
+++ b/src/Query/Postgresql/Second.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Second extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Second extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/StrToDate.php
+++ b/src/Query/Postgresql/StrToDate.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class StrToDate extends FunctionNode
 {
@@ -13,21 +13,21 @@ class StrToDate extends FunctionNode
 
     public $dateFormat = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->dateString = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->dateFormat = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'TO_DATE(' .
             $this->dateString->dispatch($sqlWalker) . ', ' .
             $this->dateFormat->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->dateString = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->dateFormat = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/StringAgg.php
+++ b/src/Query/Postgresql/StringAgg.php
@@ -5,9 +5,9 @@ namespace DoctrineExtensions\Query\Postgresql;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\OrderByClause;
 use Doctrine\ORM\Query\AST\PathExpression;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Roberto Júnior <me@robertojunior.net>
@@ -23,29 +23,6 @@ class StringAgg extends FunctionNode
 
     private bool $isDistinct = false;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $lexer = $parser->getLexer();
-        if ($lexer->isNextToken(Lexer::T_DISTINCT)) {
-            $parser->match(Lexer::T_DISTINCT);
-
-            $this->isDistinct = true;
-        }
-
-        $this->expression = $parser->PathExpression(PathExpression::TYPE_STATE_FIELD);
-        $parser->match(Lexer::T_COMMA);
-        $this->delimiter = $parser->StringPrimary();
-
-        if ($lexer->isNextToken(Lexer::T_ORDER)) {
-            $this->orderBy = $parser->OrderByClause();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return \sprintf(
@@ -55,5 +32,28 @@ class StringAgg extends FunctionNode
             $sqlWalker->walkStringPrimary($this->delimiter),
             ($this->orderBy ? $sqlWalker->walkOrderByClause($this->orderBy) : '')
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $lexer = $parser->getLexer();
+        if ($lexer->isNextToken(TokenType::T_DISTINCT)) {
+            $parser->match(TokenType::T_DISTINCT);
+
+            $this->isDistinct = true;
+        }
+
+        $this->expression = $parser->PathExpression(PathExpression::TYPE_STATE_FIELD);
+        $parser->match(TokenType::T_COMMA);
+        $this->delimiter = $parser->StringPrimary();
+
+        if ($lexer->isNextToken(TokenType::T_ORDER)) {
+            $this->orderBy = $parser->OrderByClause();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Postgresql/Year.php
+++ b/src/Query/Postgresql/Year.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Postgresql;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Year extends FunctionNode
 {
@@ -21,9 +21,9 @@ class Year extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/AbstractStrfTime.php
+++ b/src/Query/Sqlite/AbstractStrfTime.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Tarjei Huse <tarjei.huse@gmail.com>
@@ -25,12 +25,12 @@ abstract class AbstractStrfTime extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     abstract protected function getFormat(): string;

--- a/src/Query/Sqlite/ConcatWs.php
+++ b/src/Query/Sqlite/ConcatWs.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Bas de Ruiter <winkbrace@gmail.com>
@@ -15,45 +15,6 @@ class ConcatWs extends FunctionNode
     private array $values = [];
 
     private bool $notEmpty = false;
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        // Add the concat separator to the values array.
-        $this->values[] = $parser->ArithmeticExpression();
-
-        // Add the rest of the strings to the values array. CONCAT_WS must
-        // be used with at least 2 strings not including the separator.
-
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 3 || $lexer->lookahead->type == Lexer::T_COMMA) {
-            $parser->match(Lexer::T_COMMA);
-            $peek = $lexer->glimpse();
-
-            $this->values[] = $peek->value == '('
-                ? $parser->FunctionDeclaration()
-                : $parser->ArithmeticExpression();
-        }
-
-        while ($lexer->lookahead->type == Lexer::T_IDENTIFIER) {
-            switch (strtolower($lexer->lookahead->value)) {
-                case 'notempty':
-                    $parser->match(Lexer::T_IDENTIFIER);
-                    $this->notEmpty = true;
-
-                    break;
-                default: // Identifier not recognized (causes exception).
-                    $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-
-                    break;
-            }
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -77,5 +38,44 @@ class ConcatWs extends FunctionNode
 
         // Return the joined query.
         return implode('', $queryBuilder);
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        // Add the concat separator to the values array.
+        $this->values[] = $parser->ArithmeticExpression();
+
+        // Add the rest of the strings to the values array. CONCAT_WS must
+        // be used with at least 2 strings not including the separator.
+
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 3 || $lexer->lookahead->type == TokenType::T_COMMA) {
+            $parser->match(TokenType::T_COMMA);
+            $peek = $lexer->glimpse();
+
+            $this->values[] = $peek->value == '('
+                ? $parser->FunctionDeclaration()
+                : $parser->ArithmeticExpression();
+        }
+
+        while ($lexer->lookahead->type == TokenType::T_IDENTIFIER) {
+            switch (strtolower($lexer->lookahead->value)) {
+                case 'notempty':
+                    $parser->match(TokenType::T_IDENTIFIER);
+                    $this->notEmpty = true;
+
+                    break;
+                default: // Identifier not recognized (causes exception).
+                    $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+
+                    break;
+            }
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/DateFormat.php
+++ b/src/Query/Sqlite/DateFormat.php
@@ -4,9 +4,9 @@ namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\ArithmeticExpression;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * This class fakes a DATE_FORMAT method for SQLite, so that we can use sqlite as drop-in replacement
@@ -38,12 +38,12 @@ class DateFormat extends FunctionNode
      */
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->date = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->format = $this->convertFormat($parser->ArithmeticExpression());
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /**

--- a/src/Query/Sqlite/Greatest.php
+++ b/src/Query/Sqlite/Greatest.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -16,25 +16,6 @@ class Greatest extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -59,5 +40,24 @@ class Greatest extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/IfElse.php
+++ b/src/Query/Sqlite/IfElse.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Mikhail Bubnov <bubnov.mihail@gmail.com>
@@ -13,20 +13,6 @@ use Doctrine\ORM\Query\SqlWalker;
 class IfElse extends FunctionNode
 {
     private $expr = [];
-
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr[] = $parser->ConditionalExpression();
-
-        for ($i = 0; $i < 2; $i++) {
-            $parser->match(Lexer::T_COMMA);
-            $this->expr[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     public function getSql(SqlWalker $sqlWalker): string
     {
@@ -36,5 +22,19 @@ class IfElse extends FunctionNode
             $sqlWalker->walkArithmeticPrimary($this->expr[1]),
             $sqlWalker->walkArithmeticPrimary($this->expr[2])
         );
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr[] = $parser->ConditionalExpression();
+
+        for ($i = 0; $i < 2; $i++) {
+            $parser->match(TokenType::T_COMMA);
+            $this->expr[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/IfNull.php
+++ b/src/Query/Sqlite/IfNull.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author winkbrace <winkbrace@gmail.com>
@@ -16,16 +16,6 @@ class IfNull extends FunctionNode
 
     private $expr2;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->expr1 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
-        $this->expr2 = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'IFNULL('
@@ -33,5 +23,15 @@ class IfNull extends FunctionNode
             . ', '
             . $sqlWalker->walkArithmeticPrimary($this->expr2)
             . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->expr1 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_COMMA);
+        $this->expr2 = $parser->ArithmeticExpression();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Least.php
+++ b/src/Query/Sqlite/Least.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vas N <phpvas@gmail.com>
@@ -15,25 +15,6 @@ class Least extends FunctionNode
     private $field = null;
 
     private $values = [];
-
-    /**
-     * @param Parser $parser
-     */
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->ArithmeticExpression();
-        $lexer = $parser->getLexer();
-
-        while (count($this->values) < 1 ||
-            $lexer->lookahead->type != Lexer::T_CLOSE_PARENTHESIS) {
-            $parser->match(Lexer::T_COMMA);
-            $this->values[] = $parser->ArithmeticExpression();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
 
     /**
      * @param SqlWalker $sqlWalker
@@ -58,5 +39,24 @@ class Least extends FunctionNode
         $query .= ')';
 
         return $query;
+    }
+
+    /**
+     * @param Parser $parser
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticExpression();
+        $lexer = $parser->getLexer();
+
+        while (count($this->values) < 1 ||
+            $lexer->lookahead->type != TokenType::T_CLOSE_PARENTHESIS) {
+            $parser->match(TokenType::T_COMMA);
+            $this->values[] = $parser->ArithmeticExpression();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Quarter.php
+++ b/src/Query/Sqlite/Quarter.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Vincent Mariani <mariani.v@sfeir.com>
@@ -14,18 +14,18 @@ class Quarter extends FunctionNode
 {
     public $quarter;
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return "CAST(((STRFTIME('%m', {$sqlWalker->walkArithmeticPrimary($this->quarter)}) + 2) / 3) as NUMBER)";
     }
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->quarter = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Random.php
+++ b/src/Query/Sqlite/Random.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 class Random extends FunctionNode
 {
@@ -16,8 +16,8 @@ class Random extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Replace.php
+++ b/src/Query/Sqlite/Replace.php
@@ -3,9 +3,9 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author winkbrace <winkbrace@gmail.com>
@@ -18,24 +18,24 @@ class Replace extends FunctionNode
 
     public $subject = null;
 
-    public function parse(Parser $parser): void
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->subject = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->search = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->replace = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         return 'REPLACE(' .
             $this->subject->dispatch($sqlWalker) . ', ' .
             $this->search->dispatch($sqlWalker) . ', ' .
             $this->replace->dispatch($sqlWalker) .
-        ')';
+            ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->subject = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->search = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->replace = $parser->ArithmeticPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Round.php
+++ b/src/Query/Sqlite/Round.php
@@ -3,7 +3,7 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\TokenType;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
@@ -16,33 +16,33 @@ class Round extends FunctionNode
 
     private $secondExpression = null;
 
-    public function parse(Parser $parser): void
-    {
-        $lexer = $parser->getLexer();
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->firstExpression = $parser->SimpleArithmeticExpression();
-
-        // parse second parameter if available
-        if (Lexer::T_COMMA === $lexer->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
-            $this->secondExpression = $parser->ArithmeticPrimary();
-        }
-
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
-    }
-
     public function getSql(SqlWalker $sqlWalker): string
     {
         // use second parameter if parsed
         if (null !== $this->secondExpression) {
             return 'ROUND('
-            . $this->firstExpression->dispatch($sqlWalker)
-            . ', '
-            . $this->secondExpression->dispatch($sqlWalker)
-            . ')';
+                . $this->firstExpression->dispatch($sqlWalker)
+                . ', '
+                . $this->secondExpression->dispatch($sqlWalker)
+                . ')';
         }
 
         return 'ROUND(' . $this->firstExpression->dispatch($sqlWalker) . ')';
+    }
+
+    public function parse(Parser $parser): void
+    {
+        $lexer = $parser->getLexer();
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->firstExpression = $parser->SimpleArithmeticExpression();
+
+        // parse second parameter if available
+        if (TokenType::T_COMMA === $lexer->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
+            $this->secondExpression = $parser->ArithmeticPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/StrfTime.php
+++ b/src/Query/Sqlite/StrfTime.php
@@ -3,10 +3,10 @@
 namespace DoctrineExtensions\Query\Sqlite;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Tarjei Huse <tarjei.huse@gmail.com>
@@ -34,14 +34,14 @@ class StrfTime extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->formatter = $parser->Literal();
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->date = $parser->ArithmeticPrimary();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Query/Sqlite/Week.php
+++ b/src/Query/Sqlite/Week.php
@@ -2,8 +2,8 @@
 
 namespace DoctrineExtensions\Query\Sqlite;
 
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * @author Aleksandr Klimenkov <alx.devel@gmail.com>
@@ -18,17 +18,17 @@ class Week extends NumberFromStrfTime
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->date = $parser->ArithmeticPrimary();
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead->type) {
-            $parser->match(Lexer::T_COMMA);
+        if (TokenType::T_COMMA === $parser->getLexer()->lookahead->type) {
+            $parser->match(TokenType::T_COMMA);
             $this->mode = $parser->Literal();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     protected function getFormat(): string


### PR DESCRIPTION
Made a start on upgrading to `doctrine/orm^3.0`

### Done
- Replaced `Lexer` with `TokenType`
  - + Made classes consistent in order of methods in `FunctionNode` (`getSql()` first)

### Todo
```
1) DoctrineExtensions\Tests\Query\Mysql\DateTest::testDateDiff
Doctrine\DBAL\Exception: Unknown column type "DateTime" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information.
```
- Currently the suite has 15 errors like above, maybe more come if the error is fixed

Not sure what is causing and how to fix this error...

### Reproduce error
Run `composer test`

If someone has a clue, feel free to takeover the PR or add commits